### PR TITLE
chore: migrate CI scripts to Bun in package.json and GitHub Actions w…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,21 +17,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          version: 9
+          bun-version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: pnpm install --frozen-lockfile
+      - run: bun install --frozen-lockfile
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm run ci:publish
+          publish: bun run ci:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "typecheck": "tsc --noEmit",
     "check-format": "prettier --check .",
     "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
-    "ci": "pnpm run build && pnpm run check-exports && pnpm run lint && pnpm run test",
-    "ci:publish": "pnpm run build && changeset publish",
-    "prepublishOnly": "pnpm run ci",
+    "ci": "bun run build && bun run check-exports && bun run lint && bun run test",
+    "ci:publish": "bun run build && changeset publish",
+    "prepublishOnly": "bun run ci",
     "local-release": "changeset version && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
…orkflow

- Updated CI commands in `package.json` to use Bun instead of pnpm.
- Modified GitHub Actions workflow to set up Bun and run installation and publish commands using Bun.